### PR TITLE
__f_extract_paths: use builtin realpath

### DIFF
--- a/functions/__f_extract_paths.fish
+++ b/functions/__f_extract_paths.fish
@@ -10,7 +10,7 @@ function __f_extract_paths -d 'Extract valid paths from string $argv[1]'
         # Tilde expansion is done only on the commandline
         set -l token (string replace -r -- '^~/' "$HOME/" "$token")
         if test -f "$token"
-            printf '%s\n' (realpath -s "$token")
+            printf '%s\n' (builtin realpath -s "$token")
         end
     end
 


### PR DESCRIPTION
The `-s` option is not available across all platforms (e.g. FreeBSD). By explicitly opting in to the built-in version we can ensure it is valid. `-s` was added in fish 3.2.